### PR TITLE
Refactored things a bit to work on standard Java/Groovy Gradle projects

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ spec/reports
 test/tmp
 test/version_tmp
 tmp
+vendor/

--- a/Rakefile
+++ b/Rakefile
@@ -1,1 +1,8 @@
-require "bundler/gem_tasks"
+require 'bundler/gem_tasks'
+require 'rake/testtask'
+
+task :default => [:test]
+
+Rake::TestTask.new(:test) do |tsk|
+  tsk.test_files = FileList['test/*_test.rb']
+end

--- a/guard-gradle.gemspec
+++ b/guard-gradle.gemspec
@@ -4,19 +4,21 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'guard/gradle/version'
 
 Gem::Specification.new do |spec|
-  spec.name          = "guard-gradle"
+  spec.name          = 'guard-gradle'
   spec.version       = Guard::GradleVersion::VERSION
-  spec.authors       = ["Bryan Ricker"]
-  spec.email         = ["bricker88@gmail.com"]
+  spec.authors       = ['Bryan Ricker']
+  spec.email         = ['bricker88@gmail.com']
   spec.description   = %q{Guard plugin for Gradle builds}
   spec.summary       = %q{Build your Java projects as you work.}
-  spec.homepage      = "https://github.com/bricker/guard-gradle"
-  spec.license       = "MIT"
+  spec.homepage      = 'https://github.com/bricker/guard-gradle'
+  spec.license       = 'MIT'
 
   spec.files         = `git ls-files`.split($/)
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
-  spec.require_paths = ["lib"]
+  spec.require_paths = ['lib']
 
-  spec.add_dependency 'guard', "~> 2.2.5"
+  spec.add_dependency 'guard', '~> 2.2.5'
+  spec.add_development_dependency 'test-unit', '>= 2.5.5'
+  spec.add_development_dependency 'mocha', '>= 1.0.0'
 end

--- a/lib/guard/gradle.rb
+++ b/lib/guard/gradle.rb
@@ -4,20 +4,38 @@ require 'guard/plugin'
 
 module Guard
 	class Gradle < Plugin
+		
+		DEF_CMD = './gradlew test'
+
 		def run_on_changes(paths)
 			if(paths.size == 1) && (Dir.glob("src/test/**/#{paths[0]}*").size > 0)
-				fire_command("./gradlew test -Dtest.single=#{paths[0]}")
+				fire_command("#{DEF_CMD} -Dtest.single=#{paths[0]}")
       		else
       			run_all
       		end
 		end
 
 		def run_all
-			fire_command('./gradlew test')
+			fire_command DEF_CMD
 		end
 
 		def fire_command(command)
-			spawn(command)
+			result = system command
+    		summary = result ? 'Success' : 'Failure'
+    		image = result ? :success : :failed
+    		notify(summary, image)
 		end
+
+		 def notify(summary, image)
+    		::Guard::Notifier.notify(summary, title: 'Nebula Test Results', image: image)
+    	end
+
+	    def start
+	    	fire_command DEF_CMD
+	    end
+
+	    def run_all
+	    	fire_command DEF_CMD
+	    end
 	end
 end

--- a/lib/guard/gradle.rb
+++ b/lib/guard/gradle.rb
@@ -1,13 +1,23 @@
-require "guard/gradle/version"
-
+require 'guard/gradle/version'
 require 'guard'
 require 'guard/plugin'
 
 module Guard
-  class Gradle < Plugin
-    def run_on_changes(paths)
-      UI.info "Building project..."
-      spawn("./gradlew build")
-    end
-  end
+	class Gradle < Plugin
+		def run_on_changes(paths)
+			if(paths.size == 1) && (Dir.glob("src/test/**/#{paths[0]}*").size > 0)
+				fire_command("./gradlew test -Dtest.single=#{paths[0]}")
+      		else
+      			run_all
+      		end
+		end
+
+		def run_all
+			fire_command('./gradlew test')
+		end
+
+		def fire_command(command)
+			spawn(command)
+		end
+	end
 end

--- a/lib/guard/gradle/templates/Guardfile
+++ b/lib/guard/gradle/templates/Guardfile
@@ -1,4 +1,3 @@
-guard :gradle do
-  watch(%r{^src/(.+)\.java$})
-  watch(%r{^src/(.+)\.xml$})
+guard :nebula do
+  watch(%r{^src/main/(.+)\.*$}) { |m| m[1].split('.')[0].split('/')[-1] }
 end

--- a/lib/guard/gradle/version.rb
+++ b/lib/guard/gradle/version.rb
@@ -1,5 +1,5 @@
 module Guard
   module GradleVersion
-    VERSION = "0.1.0"
+    VERSION = '0.2.0'
   end
 end

--- a/test/guard_gradle_test.rb
+++ b/test/guard_gradle_test.rb
@@ -1,0 +1,24 @@
+require 'bundler/setup'
+require 'test/unit'
+require 'mocha/test_unit'
+
+require File.expand_path(File.dirname(__FILE__) + '/../lib/guard/gradle')
+
+class GuardGradleTest  < Test::Unit::TestCase
+
+	def test_single_should_be_executed
+		plugin = Guard::Gradle.new
+		expected = 'User'
+		plugin.expects(:fire_command).with("./gradlew test -Dtest.single=#{expected}")
+		Dir.expects(:glob).returns([true])
+		plugin.run_on_changes [expected]
+	end
+
+	def test_all_when_file_not_found
+		plugin = Guard::Gradle.new
+		expected = 'User'
+		plugin.expects(:fire_command).with('./gradlew test')
+		Dir.expects(:glob).returns([])
+		plugin.run_on_changes [expected]
+	end
+end


### PR DESCRIPTION
I love your plugin, however, it seems rather tied directly to Android based projects. So, I've updated the default Guard file template to watch a standard Java directory structure and made the Guard logic execute single test for Gradle. If the file isn't found then the entire test suite is executed. I also added some simple tests, which required that I add some new dependencies (however, they aren't required for people that use the GEM). 

If you aren't happy w/this Pull Request, maybe we should rename your plugin to Guard:Android and then this PR could become the more generic Guard:Gradle? 

What do you think? 
