### PR TITLE
guard version change up to 2.16.2

### DIFF
--- a/guard-gradle.gemspec
+++ b/guard-gradle.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'guard', '~> 2.6.1'
+  spec.add_dependency 'guard', '~> 2.16.2'
   spec.add_development_dependency 'test-unit', '>= 2.5.5'
   spec.add_development_dependency 'mocha', '>= 1.0.0'
 end


### PR DESCRIPTION
Hi.
Thanks for good library.

However, I get an error when I run this library.

```
use ruby version: 2.6.3
```

![image](https://user-images.githubusercontent.com/529166/111121855-878f8400-85b0-11eb-88f6-1a93b636b8d0.png)

```
$ bundle exec guard
Deprecation warning: Expected string default value for '--listen-on'; got false (boolean).
This will be rejected in the future unless you explicitly pass the options `check_default_type: false` or call `allow_incompatible_default_type!` in your code
You can silence deprecations warning by setting the environment variable THOR_SILENCE_DEPRECATION.
17:04:16 - INFO - Guard is using TerminalTitle to send notifications.
bundler: failed to load command: guard (/home/areph/.anyenv/envs/rbenv/versions/2.6.3/bin/guard)
NoMethodError: undefined method `file=' for #<Pry::History:0x00000000013aa880>
Did you mean?  filter
  /home/areph/.anyenv/envs/rbenv/versions/2.6.3/lib/ruby/gems/2.6.0/gems/guard-2.6.1/lib/guard/interactor.rb:107:in `initialize'
  /home/areph/.anyenv/envs/rbenv/versions/2.6.3/lib/ruby/gems/2.6.0/gems/guard-2.6.1/lib/guard/setuper.rb:90:in `new'
  /home/areph/.anyenv/envs/rbenv/versions/2.6.3/lib/ruby/gems/2.6.0/gems/guard-2.6.1/lib/guard/setuper.rb:90:in `interactor'
  /home/areph/.anyenv/envs/rbenv/versions/2.6.3/lib/ruby/gems/2.6.0/gems/guard-2.6.1/lib/guard/commander.rb:107:in `block in within_preserved_state'
  /home/areph/.anyenv/envs/rbenv/versions/2.6.3/lib/ruby/gems/2.6.0/gems/guard-2.6.1/lib/guard/commander.rb:105:in `synchronize'
  /home/areph/.anyenv/envs/rbenv/versions/2.6.3/lib/ruby/gems/2.6.0/gems/guard-2.6.1/lib/guard/commander.rb:105:in `within_preserved_state'
  /home/areph/.anyenv/envs/rbenv/versions/2.6.3/lib/ruby/gems/2.6.0/gems/guard-2.6.1/lib/guard/commander.rb:26:in `start'
  /home/areph/.anyenv/envs/rbenv/versions/2.6.3/lib/ruby/gems/2.6.0/gems/guard-2.6.1/lib/guard/cli.rb:107:in `start'
  /home/areph/.anyenv/envs/rbenv/versions/2.6.3/lib/ruby/gems/2.6.0/gems/thor-1.1.0/lib/thor/command.rb:27:in `run'
  /home/areph/.anyenv/envs/rbenv/versions/2.6.3/lib/ruby/gems/2.6.0/gems/thor-1.1.0/lib/thor/invocation.rb:127:in `invoke_command'
  /home/areph/.anyenv/envs/rbenv/versions/2.6.3/lib/ruby/gems/2.6.0/gems/thor-1.1.0/lib/thor.rb:392:in `dispatch'
  /home/areph/.anyenv/envs/rbenv/versions/2.6.3/lib/ruby/gems/2.6.0/gems/thor-1.1.0/lib/thor/base.rb:485:in `start'
  /home/areph/.anyenv/envs/rbenv/versions/2.6.3/lib/ruby/gems/2.6.0/gems/guard-2.6.1/bin/guard:6:in `<top (required)>'
  /home/areph/.anyenv/envs/rbenv/versions/2.6.3/bin/guard:23:in `load'
  /home/areph/.anyenv/envs/rbenv/versions/2.6.3/bin/guard:23:in `<top (required)>'
```

I think this error occurs because the version of guard is old.

So I upgraded the version of guard to the latest 2.16.2 and it ran fine.

![image](https://user-images.githubusercontent.com/529166/111122633-a2aec380-85b1-11eb-9c9a-f25b360f35a4.png)


I'd be happy to accept this PR if you'd like. Thanks.
